### PR TITLE
code update

### DIFF
--- a/src/Transliterate.jl
+++ b/src/Transliterate.jl
@@ -35,7 +35,7 @@ function transliterate(str, languages; custom_replacements = Dict())
     end
 
     for language in languages
-        # TODO: Here should be some warnings/safety belts added
+        # TODO: Add warning if a specified language is missing
         lang_id = findfirst(x -> x.first == language, replacements)
         d = replacements[lang_id].second
         str = foldl(replace, d, init = str)

--- a/src/Transliterate.jl
+++ b/src/Transliterate.jl
@@ -4,6 +4,10 @@ export transliterate, replacements
 
 include("replacements.jl")
 
+wrap_languages(languages::AbstractString) = [languages]
+wrap_languages(languages::Nothing) = first.(replacements)
+wrap_languages(languages) = isempty(languages) ? wrap_languages(nothing) : languages
+
 """
     transliterate(str; languages=[], custom_replacements=Dict())
 
@@ -21,24 +25,22 @@ julia> transliterate("≠ ∉"; custom_replacements=Dict("≠" => "not equal", "
 "not equal not in"
 ```
 """
-function transliterate(str; languages=[], custom_replacements=Dict())
-    if typeof(languages) <: AbstractString
-        languages = [languages]
-    end
-    if languages == []
-        languages = collect(keys(replacements))
-    end
+transliterate(str; languages = nothing, custom_replacements = Dict()) = transliterate(str, wrap_languages(languages); custom_replacements = custom_replacements)
+
+function transliterate(str, languages; custom_replacements = Dict())
+    str = foldl(replace, custom_replacements, init = str)
+
     if "la" ∉ languages
-        pushfirst!(languages, "la")
+        str = foldl(replace, replacements[1].second, init = str)
     end
 
     for language in languages
-        merge!(custom_replacements, replacements[language])
+        # TODO: Here should be some warnings/safety belts added
+        lang_id = findfirst(x -> x.first == language, replacements)
+        d = replacements[lang_id].second
+        str = foldl(replace, d, init = str)
     end
 
-    for pair in custom_replacements
-        str = replace(str, pair.first => pair.second)
-    end
     return str
 end
 

--- a/src/replacements.jl
+++ b/src/replacements.jl
@@ -1,6 +1,6 @@
 # Source: https://github.com/sindresorhus/transliterate/blob/master/replacements.js
 
-const replacements = Dict(
+const replacements = [
     # General (named Latin in the source)
     "la" => Dict(
         "À" => "A",
@@ -377,8 +377,8 @@ const replacements = Dict(
         "ч" => "ch",
         "Ш" => "Sh",
         "ш" => "sh",
-        "Щ" => "Shh",
-        "щ" => "shh",
+        "Щ" => "Shch",
+        "щ" => "shch",
         "Ъ" => "",
         "ъ" => "",
         "Ы" => "Y",
@@ -808,4 +808,4 @@ const replacements = Dict(
         "ø" => "oe",
         "å" => "aa"
     )
-)
+]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,7 @@ using Transliterate
 using Test
 
 @testset "transliterate" begin
-    @test transliterate("абвгдђежзијклљмнњопрстћуфхцчџш") == "abvgddjezhzijklljmnnjoprstcufhcchdzsh"
+    @test transliterate("абвгдђежзијклљмнњопрстћуфхцчџш") == "abvgddjezhzijklljmnnjoprstcufhczchdzsh"
     @test transliterate("Привет") == "Privet"
     @test transliterate("Foo ÿ") == "Foo y"
 	@test transliterate("Hællæ, hva skjera?") == "Haellae, hva skjera?"
@@ -10,5 +10,8 @@ using Test
 
     @test transliterate("ث س و"; languages="ar") == "th s w"
 
-    @test transliterate("≠ ∉"; custom_replacements=Dict("≠" => "not equal", "∉" => "not in")) == "not equal not in"
+    custom_replacements = Dict("≠" => "not equal", "∉" => "not in")
+    custom_replacements_copy = deepcopy(custom_replacements)
+    @test transliterate("≠ ∉"; custom_replacements = custom_replacements) == "not equal not in"
+    @test custom_replacements == custom_replacements_copy
 end


### PR DESCRIPTION
Hello! This PR contains some bug fixes and more idiomatic julia expressions.

1. `languages` argument now processed in `wrap_languages` with the help of multiple dispatch and now can accept `nothing` as well as an empty array.
2. The new version of `transliterate` function was added, which serves as [function barrier](https://docs.julialang.org/en/v1/manual/performance-tips/index.html#kernel-functions-1)
3. The original version had a side effect of introducing mutations in `languages` and `custom_replacements` arguments. Consider following code snippet:
```julia
langs = ["ru"]
transliterate("Привет", languages = langs)
println(langs)
# ["la", "ru"]
```
take notice of new "la" element in the original array.

4.Current replacement rules intersect with each other and producing different results. Since they all were packed in `Dict` which doesn't guarantee the order of `collect(keys)` different results can be obtained on different runs. In current proposal, the randomity issue was solved by using `Vector` of `Pair` instead of `Dict`. Another possible solution is to use `OrderedDict`.

5. There was a small error in `Russian` transliteration table.